### PR TITLE
Adds maliput_malidrive documentation.

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(ament_cmake_doxygen REQUIRED)
 ament_doxygen_generate(doxygen_maliput_docs
   PROJECT_NAME maliput-docs STANDALONE
   BUILD_DIRECTORY ${SPHINX_BUILD}/from_doxygen
-  DEPENDENCIES malidrive maliput maliput_dragway
+  DEPENDENCIES maliput maliput_dragway maliput_malidrive
                maliput_multilane maliput_integration
                maliput_integration_tests
 )

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -8,11 +8,11 @@ Maliput
 * `Maliput Design <from_doxygen/html/deps/maliput/html/maliput_design.html>`_
 * `Maliput C++ namespace <from_doxygen/html/deps/maliput/html/namespacemaliput.html>`_
 
-Malidrive
-=========
+Maliput Malidrive
+=================
 
-* `RoadCurve design <from_doxygen/html/deps/malidrive/html/malidrive_road_curve_design.html>`_
-* `Malidrive C++ namespace <from_doxygen/html/deps/malidrive/html/namespacemalidrive.html>`_
+* `RoadCurve design <from_doxygen/html/deps/maliput_malidrive/html/malidrive_road_curve_design.html>`_
+* `Maliput_malidrive C++ namespace <from_doxygen/html/deps/maliput_malidrive/html/namespacemalidrive.html>`_
 
 Dragway
 =======

--- a/package.xml
+++ b/package.xml
@@ -17,8 +17,8 @@
   <build_depend>maliput_dragway</build_depend>
   <build_depend>maliput_integration</build_depend>
   <build_depend>maliput_integration_tests</build_depend>
+  <build_depend>maliput_malidrive</build_depend>
   <build_depend>maliput_multilane</build_depend>
-  <build_depend>malidrive</build_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Bring doxygen documentation from `maliput_malidrive` instead of `malidrive`.