### PR TITLE
Adds extra steps in the workflow to commit changes to gh-pages.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,13 +111,15 @@ jobs:
       run: |
         . /opt/ros/${ROS_DISTRO}/setup.bash;
         colcon build --packages-up-to ${PACKAGE_NAME} --event-handlers=console_direct+;
-    # checkouts to gh-pages
+    # checkout to gh-pages
     - uses: actions/checkout@v2
+      if: ${{ github.event_name == 'schedule' }}
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}
         ref: gh-pages
-    # dumps the content
+    # dump the content into gh-pages
     - name: push to gh-pages
+      if: ${{ github.event_name == 'schedule' }}
       shell: bash
       working-directory: ${{ env.ROS_WS }}
       run: |


### PR DESCRIPTION
Runs a nightly build of the documentation.

Please take a look at https://github.com/ToyotaResearchInstitute/maliput-documentation/tree/gh-pages branch to see the output.

Users could do the following to visualize the documentation:

```sh
git fetch origin
git checkout gh-pages
```

and 

```sh
xdg-open index.html
```

or

```sh
google-chrome index.html
```

Solves #24 