### PR TITLE
Fix note about copying delphyne.repos file.

### DIFF
--- a/docs/installation_quickstart.rst
+++ b/docs/installation_quickstart.rst
@@ -88,7 +88,7 @@ folder. It will be used to bring all the repositories later on.
 
     cp repos_index/dashing/maliput.repos maliput_ws/
 
-.. note:
+.. note::
   If you would like to bring the ``delphyne`` repositories too, you should also
   copy `delphyne.repos <https://github.com/ToyotaResearchInstitute/repos_index/blob/main/dashing/delphyne.repos>`_.
 


### PR DESCRIPTION
Part of #29 

![image](https://user-images.githubusercontent.com/3825465/117009753-79153d00-acc2-11eb-94d1-21b9a7384257.png)
