### PR TITLE
Use include instead of CMAKE_INSTALL_INCLUDEDIR

### DIFF
--- a/docs/developer_guidelines.rst
+++ b/docs/developer_guidelines.rst
@@ -155,7 +155,7 @@ Libraries
     target_include_directories(foo
       PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+        $<INSTALL_INTERFACE:include>
     )
 
 * Header file only libraries should be created as interfaces and header files


### PR DESCRIPTION
CMAKE_INSTALL_INCLUDEDIR requires GNUInstallDirs,
which is not included by default on foxy, so just
use "include" explicitly.

Related to https://github.com/ToyotaResearchInstitute/maliput/pull/424, part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196