### PR TITLE
rosdep update --include-eol-distros

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
       shell: bash
       working-directory: ${{ env.ROS_WS }}
       run: |
-        rosdep update;
+        rosdep update --include-eol-distros;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} --skip-keys "pybind11" --from-paths src
     - name: install drake
       shell: bash

--- a/docs/installation_quickstart.rst
+++ b/docs/installation_quickstart.rst
@@ -144,6 +144,16 @@ Install dependencies via ``rosdep``
     rosdep update
     rosdep install -i -y --rosdistro $ROS_DISTRO --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui0 ignition-gui3 ignition-rendering3 pybind11" --from-paths src
 
+
+Sometimes, you might be working with EOL ROS2 distributions. If that's the case, make sure to run ``rosdep update`` with
+``--include-eol-distros`` flag as follows:
+
+
+.. code-block:: sh
+
+    rosdep update --include-eol-distros
+
+
 .. warning::
   Package dependencies are installed system wide. ``rosdep`` does not provide any support to remove the dependencies it
   brings. In this regard, disposable containerized workspaces help keep development environments clean (as system wide


### PR DESCRIPTION
`dashing` is now end-of-life so we should use `--include-eol-distros` with `rosdep update`

See https://github.com/ToyotaResearchInstitute/maliput/pull/425

Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196