### PR TITLE
Makes the documentation foxy aware.

### DIFF
--- a/docs/installation_quickstart.rst
+++ b/docs/installation_quickstart.rst
@@ -85,7 +85,7 @@ Copy .repos file
 
     cp repos_index/dashing/maliput.repos maliput_ws/
 
-**For foxy:** copy ``repos_index/dashing/maliput.repos`` into ``maliput_ws``. It will be used to add the Maliput-related repositories to the workspace.
+**For foxy:** copy ``repos_index/foxy/maliput.repos`` into ``maliput_ws``. It will be used to add the Maliput-related repositories to the workspace.
 
 .. code-block:: sh
 


### PR DESCRIPTION
- Adds the -o / --os flag to the docker build and run script.
- References the foxy repos file.

Related to:
- https://github.com/ToyotaResearchInstitute/repos_index/pull/24
- https://github.com/ToyotaResearchInstitute/maliput_infrastructure/pull/219