### PR TITLE
Improves documentation by adding alternate key servers for ignition.

### DIFF
--- a/docs/installation_quickstart.rst
+++ b/docs/installation_quickstart.rst
@@ -193,6 +193,8 @@ Sometimes, you might be working with EOL ROS2 distributions. If that's the case,
                      libignition-gui3-dev \
                      libignition-transport8-dev
 
+  It might be the case that the command ``apt-key adv`` fails. Consider using other key servers like ``hkp://pgp.mit.edu:80`` or ``hkp://keyserver.ubuntu.com:80`` to effectively run that command.
+
 .. _install-drake:
 
 Install drake
@@ -645,6 +647,8 @@ Install ignition binaries
                    libignition-rendering3-dev \
                    libignition-gui3-dev \
                    libignition-transport8-dev
+
+It might be the case that the command ``apt-key adv`` fails. Consider using other key servers like ``hkp://pgp.mit.edu:80`` or ``hkp://keyserver.ubuntu.com:80`` to effectively run that command.
 
 From then on, before building the workspace, you must source the underlay as follows:
 


### PR DESCRIPTION
We often encounter errors when installing in our docker containers ignition packages. In CI, that is not the case because a for-loop (see [here](https://github.com/ToyotaResearchInstitute/delphyne/blob/main/.github/ignition_packages_installation.sh#L3-L23)) tries three key servers. This PR formalizes in the documentation the three alternatives by adding notes where ignition packages are required.