### PR TITLE
Build docs using only focal in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,39 +9,20 @@ on:
 
 env:
   PACKAGE_NAME: maliput_documentation
+  ROS_DISTRO: foxy
   ROS_WS: maliput_ws
 
 jobs:
   compile:
     name: Compile
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ubuntu: [18.04, 20.04]
-        include:
-          - ubuntu: 18.04
-            ROS_DISTRO: dashing
-          - ubuntu: 20.04
-            ROS_DISTRO: foxy
     container:
-      image: ubuntu:${{ matrix.ubuntu }}
-    env:
-      ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
+      image: ubuntu:20.04
     steps:
     # setup-ros first since it installs git, which is needed to fetch all branches from actions/checkout
     - uses: ros-tooling/setup-ros@0.2.1
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-    # install git from ppa since git 2.18+ is needed to fetch all branches from actions/checkout
-    # this step can be removed on 20.04
-    - name: install git from ppa
-      if: matrix.ubuntu == '18.04'
-      shell: bash
-      run: |
-        apt update;
-        apt install -y software-properties-common;
-        add-apt-repository -y -u ppa:git-core/ppa;
-        apt install -y git;
     - uses: actions/checkout@v2
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}


### PR DESCRIPTION
CI can run only in focal and save some GH Actions minutes. 

This smooths the path for adding delphyne repos at https://github.com/ToyotaResearchInstitute/maliput_documentation/pull/57