### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Maliput Documentation
 
-High level documentation (sphinx) and Changelog for maliput & family.
+Documentation and Changelog for Maliput & family.
 
 # Introduction
 
-In order to build high level documentation
-this repository gathers documentation from:
+Maliput's documentation is generated using [Sphinx](https://www.sphinx-doc.org/en/master/) using information gathered
+from:
  - [maliput](https://github.com/ToyotaResearchInstitute/maliput)
  - [maliput_malidrive](https://github.com/ToyotaResearchInstitute/maliput_malidrive)
  - [maliput_dragway](https://github.com/ToyotaResearchInstitute/maliput_dragway)
@@ -21,7 +21,47 @@ this repository gathers documentation from:
 
 ## Requirements
 
- * Workspace must be created as it is explained in [Installation & Quickstart](docs/installation_quickstart.rst).
+ * Workspace must be created, see [Installation & Quickstart](docs/installation_quickstart.rst).
+
+__Note:__ If you are using ROS 2 Dashing, modify your workspace by performing the following steps. This is necessary
+because `maliput_documentation` includes `delphyne` and is thus part of `delphyne.repos`, which is only supported by
+ROS 2 Foxy. The following bypasses this problem and enables building the documentation on ROS 2 Dashing.
+
+Grab the ROS 2 Foxy version of `delphyne.repos`. From outside of your container (if you are using a containerized
+workspace), in the directory that holds `maliput_ws`:
+
+```sh
+cp repos_index/foxy/delphyne.repos maliput_ws/
+
+```
+
+Enter your container (if you are using a containerized workspace), then:
+
+```sh
+vcs import src < delphyne.repos
+vcs pull src
+rosdep update --include-eol-distros
+rosdep install -i -y --rosdistro $ROS_DISTRO \
+    --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui3 ignition-rendering3 pybind11" \
+    --from-paths src
+
+echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | \
+    sudo tee --append /etc/apt/sources.list.d/gazebo-stable.list
+sudo apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+sudo apt update
+sudo apt -y install --no-install-recommends \
+               libignition-common3-dev \
+               libignition-math6-dev \
+               libignition-msgs5-dev \
+               libignition-tools-dev \
+               libignition-cmake2-dev \
+               libignition-rendering3-dev \
+               libignition-gui3-dev \
+               libignition-transport8-dev
+```
+
+__Note:__ If the `apt-key` command fails, try a different key server like `hkp://pgp.mit.edu:80` or
+`hkp://keyserver.ubuntu.com:80`.
 
 ## Build
 
@@ -31,12 +71,20 @@ this repository gathers documentation from:
 
 # Visualize
 
-During building, several files are generated in the `build` folder.
-To visualize the documentation it is needed to open the `index.html` file with your preferred browser:
+When building the workspace, the generated documentation is saved in `build/maliput_documentation/docs/docs/sphinx`.
+To visualize it, open `index.html` using your preferred browser.
 
-Standing in the root of the workspace.
+_Note:_ If your workspace is containerized, execute the following *outside of your container*. This is because
+`xdg-open` is not installed in your container.
+
+From the workspace root:
+
 ```sh
 xdg-open build/maliput_documentation/docs/docs/sphinx/index.html
 ```
 
-_Note:_ Run this command outside the docker container, `xdg-open` is not installed.
+If you encounter an error saying `xdg-open` is not installed, install it using the following:
+
+```sh
+sudo apt install xdg-utils
+```


### PR DESCRIPTION
 - Include instructions for users of ROS 2 Dashing.
 - Move the note about executing the open-documentation commands
   outside of a container earlier to avoid surprising readers.
 - Polish text a bit for clarity.