### PR TITLE
Add maliput_drake to CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,12 @@ jobs:
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
+        repository: ToyotaResearchInstitute/maliput_drake
+        fetch-depth: 0
+        path: ${{ env.ROS_WS }}/src/maliput_drake
+        token: ${{ secrets.MALIPUT_TOKEN }}
+    - uses: actions/checkout@v2
+      with:
         repository: ToyotaResearchInstitute/drake-vendor
         fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/drake_vendor


### PR DESCRIPTION
Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/232

Add maliput_drake to CI to satisfy backend dependencies.