### PR TITLE
Adds BUILD_DOCS flag.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,13 @@ find_package(ament_cmake REQUIRED)
 ##############################################################################
 # Docs
 ##############################################################################
-add_subdirectory("docs")
+
+if(BUILD_DOCS)
+  message(STATUS "Documentation build - Enabled")
+  add_subdirectory("docs")
+else()
+  message(STATUS "Documentation build - Disabled")
+endif()
 
 
 ament_package()

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ __Note:__ If the `apt-key` command fails, try a different key server like `hkp:/
 ## Build
 
 ```sh
-  colcon build --packages-up-to maliput_documentation
+  colcon build --packages-up-to maliput_documentation --cmake-args " -DBUILD_DOCS=On"
 ```
 
 # Visualize


### PR DESCRIPTION
Related to https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/244
Related to https://github.com/ToyotaResearchInstitute/maliput_documentation/issues/81

### Summary

For consistency, the `BUILD_DOCS` flag needs to be added here as well.

This solves CI failing in `maliput_infraestructure`.


