### PR TITLE
Adds maliput_object_py

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -1,9 +1,17 @@
 repositories:
-  ament_cmake_doxygen:
-    type: git
-    url: https://github.com/ToyotaResearchInstitute/ament_cmake_doxygen
-    version: main
-  pybind11:
-    type: git
-    url: https://github.com/RobotLocomotion/pybind11.git
-    version: c39ede1eedd4f39aa167d7b30b53ae45967c39b7
+  ament_cmake_doxygen       : { type: 'git', url: 'https://github.com/ToyotaResearchInstitute/ament_cmake_doxygen.git',   version: 'main' }
+  delphyne                  : { type: 'git', url: 'https://github.com/maliput/delphyne.git',                              version: 'main' }
+  delphyne_demos            : { type: 'git', url: 'https://github.com/maliput/delphyne_demos.git',                        version: 'main' }
+  delphyne_gui              : { type: 'git', url: 'https://github.com/maliput/delphyne_gui.git',                          version: 'main' }
+  drake_vendor              : { type: 'git', url: 'https://github.com/maliput/drake_vendor.git',                          version: 'main' }
+  maliput                   : { type: 'git', url: 'https://github.com/maliput/maliput.git',                               version: 'main' }
+  maliput_object            : { type: 'git', url: 'https://github.com/maliput/maliput_object.git',                        version: 'main' }
+  maliput_object_py         : { type: 'git', url: 'https://github.com/maliput/maliput_object_py.git',                     version: 'main' }
+  maliput_drake             : { type: 'git', url: 'https://github.com/maliput/maliput_drake.git',                         version: 'main' }
+  maliput_integration       : { type: 'git', url: 'https://github.com/maliput/maliput_integration.git',                   version: 'main' }
+  maliput_integration_tests : { type: 'git', url: 'https://github.com/maliput/maliput_integration_tests.git',             version: 'main' }
+  maliput_malidrive         : { type: 'git', url: 'https://github.com/maliput/maliput_malidrive.git',                     version: 'main' }
+  maliput_py                : { type: 'git', url: 'https://github.com/maliput/maliput_py.git',                            version: 'main' }
+  maliput_dragway           : { type: 'git', url: 'https://github.com/maliput/maliput_dragway.git',                       version: 'main' }
+  maliput_multilane         : { type: 'git', url: 'https://github.com/maliput/maliput_multilane.git',                     version: 'main' }
+  pybind11                  : { type: 'git', url: 'https://github.com/RobotLocomotion/pybind11.git',                      version: 'c39ede1eedd4f39aa167d7b30b53ae45967c39b7'  }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ jobs:
       working-directory: ${{ env.ROS_WS }}
       run: |
         . /opt/ros/${ROS_DISTRO}/setup.bash;
+        . install/setup.bash;
         colcon build --packages-up-to ${PACKAGE_NAME} --packages-skip ament_cmake_doxygen --cmake-args " -DBUILD_DOCS=On" --event-handlers=console_direct+;
     # checkout to gh-pages
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,94 +28,15 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}
-    # clone private dependencies
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/maliput
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/maliput_object
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput_object
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/maliput_py
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput_py
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/maliput_malidrive
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput_malidrive
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/maliput_dragway
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput_dragway
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/maliput_multilane
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput_multilane
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/maliput_integration
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput_integration
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/maliput_integration_tests
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput_integration_tests
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/maliput_drake
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput_drake
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/drake-vendor
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/drake_vendor
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/delphyne
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/delphyne
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/delphyne_gui
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/delphyne_gui
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/delphyne_demos
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/delphyne_demos
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - name: check if dependencies have a matching branch
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}/src
-      run: ./${PACKAGE_NAME}/.github/try_vcs_checkout ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} .
     # clone public dependencies
     - name: vcs import
       shell: bash
       working-directory: ${{ env.ROS_WS }}
       run: vcs import src < src/${PACKAGE_NAME}/.github/dependencies.repos
+    - name: check if dependencies have a matching branch
+      shell: bash
+      working-directory: ${{ env.ROS_WS }}/src
+      run: ./${PACKAGE_NAME}/.github/try_vcs_checkout ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} .
     - run: colcon graph
       shell: bash
       working-directory: ${{ env.ROS_WS }}
@@ -129,12 +50,18 @@ jobs:
       shell: bash
       working-directory: ${{ env.ROS_WS }}/src/drake_vendor
       run: ./drake_installer
+    - name: colcon build ament_cmake_doxygen
+      shell: bash
+      working-directory: ${{ env.ROS_WS }}
+      run: |
+        . /opt/ros/${ROS_DISTRO}/setup.bash;
+        colcon build --packages-select ament_cmake_doxygen --event-handlers=console_direct+;
     - name: colcon build
       shell: bash
       working-directory: ${{ env.ROS_WS }}
       run: |
         . /opt/ros/${ROS_DISTRO}/setup.bash;
-        colcon build --packages-up-to ${PACKAGE_NAME} --cmake-args " -DBUILD_DOCS=On" --event-handlers=console_direct+;
+        colcon build --packages-up-to ${PACKAGE_NAME} --packages-skip ament_cmake_doxygen --cmake-args " -DBUILD_DOCS=On" --event-handlers=console_direct+;
     # checkout to gh-pages
     - uses: actions/checkout@v2
       if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(ament_cmake_doxygen REQUIRED)
 ament_doxygen_generate(doxygen_maliput_docs
   PROJECT_NAME maliput-docs STANDALONE
   BUILD_DIRECTORY ${SPHINX_BUILD}/from_doxygen
-  DEPENDENCIES maliput maliput_object maliput_py maliput_dragway maliput_malidrive
+  DEPENDENCIES maliput maliput_object maliput_object_py maliput_py maliput_dragway maliput_malidrive
                maliput_multilane maliput_integration
                maliput_integration_tests delphyne delphyne_gui delphyne_demos
 )

--- a/docs/developer_guidelines.rst
+++ b/docs/developer_guidelines.rst
@@ -15,8 +15,9 @@ The following packages are provided:
 
 * Core packages:
     * `maliput`_
-    * `maliput_object`_
     * `maliput_py`_
+    * `maliput_object`_
+    * `maliput_object_py`_
     * `ament_cmake_doxygen`_
     * `maliput_documentation`_
 * Backend implementations:
@@ -31,29 +32,28 @@ The following packages are provided:
 * Utility packages:
     * `drake_vendor`_
     * `pybind11`_
-    * `dsim_docs_bundler`_
 * Delphyne:
     * `delphyne`_
     * `delphyne_gui`_
     * `delphyne_demos`_
 
-.. _maliput: https://github.com/ToyotaResearchInstitute/maliput
-.. _maliput_object: https://github.com/ToyotaResearchInstitute/maliput_object
-.. _maliput_py: https://github.com/ToyotaResearchInstitute/maliput_py
+.. _maliput: https://github.com/maliput/maliput
+.. _maliput_py: https://github.com/maliput/maliput_py
+.. _maliput_object: https://github.com/maliput/maliput_object
+.. _maliput_object: https://github.com/maliput/maliput_object_py
 .. _ament_cmake_doxygen: https://github.com/ToyotaResearchInstitute/ament_cmake_doxygen
-.. _maliput_documentation: https://github.com/ToyotaResearchInstitute/maliput_documentation
-.. _maliput_dragway: https://github.com/ToyotaResearchInstitute/maliput_dragway
-.. _maliput_malidrive: https://github.com/ToyotaResearchInstitute/maliput_malidrive
-.. _maliput_multilane: https://github.com/ToyotaResearchInstitute/maliput_multilane
-.. _maliput_integration: https://github.com/ToyotaResearchInstitute/maliput_integration
-.. _maliput_integration_tests: https://github.com/ToyotaResearchInstitute/maliput_integration_tests
-.. _maliput_drake: https://github.com/ToyotaResearchInstitute/maliput_drake
-.. _drake_vendor: https://github.com/ToyotaResearchInstitute/drake_vendor
+.. _maliput_documentation: https://github.com/maliput/maliput_documentation
+.. _maliput_dragway: https://github.com/maliput/maliput_dragway
+.. _maliput_malidrive: https://github.com/maliput/maliput_malidrive
+.. _maliput_multilane: https://github.com/maliput/maliput_multilane
+.. _maliput_integration: https://github.com/maliput/maliput_integration
+.. _maliput_integration_tests: https://github.com/maliput/maliput_integration_tests
+.. _maliput_drake: https://github.com/maliput/maliput_drake
+.. _drake_vendor: https://github.com/maliput/drake_vendor
 .. _pybind11: https://github.com/RobotLocomotion/pybind11
-.. _dsim_docs_bundler: https://github.com/ToyotaResearchInstitute/dsim_docs_bundler
-.. _delphyne: https://github.com/ToyotaResearchInstitute/delphyne
-.. _delphyne_gui: https://github.com/ToyotaResearchInstitute/delphyne_gui
-.. _delphyne_demos: https://github.com/ToyotaResearchInstitute/delphyne_demos
+.. _delphyne: https://github.com/maliput/delphyne
+.. _delphyne_gui: https://github.com/maliput/delphyne_gui
+.. _delphyne_demos: https://github.com/maliput/delphyne_demos
 
 Each repository may contain one or more packages. When a repository contains
 two or more packages, it is expected that all packages' versions within the same

--- a/package.xml
+++ b/package.xml
@@ -17,13 +17,14 @@
   <build_depend>delphyne_gui</build_depend>
   <build_depend>delphyne_demos</build_depend>
   <build_depend>maliput</build_depend>
-  <build_depend>maliput_object</build_depend>
-  <build_depend>maliput_py</build_depend>
   <build_depend>maliput_dragway</build_depend>
   <build_depend>maliput_integration</build_depend>
   <build_depend>maliput_integration_tests</build_depend>
   <build_depend>maliput_malidrive</build_depend>
   <build_depend>maliput_multilane</build_depend>
+  <build_depend>maliput_object</build_depend>
+  <build_depend>maliput_object_py</build_depend>
+  <build_depend>maliput_py</build_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Related to https://github.com/maliput/maliput_object_py/issues/2

### Summary

- Fixe CI after `ament_cmake_doxygen` change in dependency type.
- Adds `maliput_object_py` info