### PR TITLE
Mentions maliput-full package in the installation page.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -84,6 +84,15 @@ Install the binaries of the packages:
 
   sudo apt install ros-foxy-<package_name>
 
+
+Use `maliput-full` package to install all the maliput packages:
+
+.. code-block:: sh
+
+  sudo apt install ros-foxy-maliput-full
+
+
+Or simple indicate the packages to install.
 For example to install `maliput_malidrive` package:
 
 .. code-block:: sh


### PR DESCRIPTION
Resolves #94 
### Summary

Adds `maliput-full` to the installation page.