### PR TITLE
Adds maliput_osm and maliput_sparse to CI and Doxygen docs generation.

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -14,3 +14,5 @@ repositories:
   maliput_py                : { type: 'git', url: 'https://github.com/maliput/maliput_py.git',                            version: 'main' }
   maliput_dragway           : { type: 'git', url: 'https://github.com/maliput/maliput_dragway.git',                       version: 'main' }
   maliput_multilane         : { type: 'git', url: 'https://github.com/maliput/maliput_multilane.git',                     version: 'main' }
+  maliput_sparse            : { type: 'git', url: 'https://github.com/maliput/maliput_sparse.git',                     version: 'main' }
+  maliput_osm         : { type: 'git', url: 'https://github.com/maliput/maliput_osm.git',                     version: 'main' }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,9 @@ if(BUILD_DOCS)
       maliput_integration_tests
       maliput_object
       maliput_object_py
+      maliput_osm
       maliput_py
+      maliput_sparse
       delphyne
       delphyne_demos
       delphyne_gui

--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,9 @@
   <build_depend>maliput_multilane</build_depend>
   <build_depend>maliput_object</build_depend>
   <build_depend>maliput_object_py</build_depend>
+  <build_depend>maliput_osm</build_depend>
   <build_depend>maliput_py</build_depend>
+  <build_depend>maliput_sparse</build_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
# 🎉 New feature

## Summary
Adds maliput_osm and maliput_sparse to the documentation.
- [x] Build doxygen documentation
- [ ] Add info to the docs.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
