### PR TITLE
Fixes tutorials sections.

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -1,3 +1,12 @@
+.. _tutorials_label:
+
+Tutorials
+=========
+
+The tutorials are a collection of step-by-step instructions meant to help you get started with Maliput ecosystem.
+
+It is recommended to visit :ref:`getting_started_label` page before diving into tutorials.
+
 .. toctree::
    :maxdepth: 2
 

--- a/docs/tutorials/maliput_integration.rst
+++ b/docs/tutorials/maliput_integration.rst
@@ -1,3 +1,8 @@
+.. _tutorial_maliput_integration_label:
+
+maliput_integration
+===================
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/tutorials/maliput_integration/maliput_integration_apps.rst
+++ b/docs/tutorials/maliput_integration/maliput_integration_apps.rst
@@ -1,7 +1,4 @@
+Applications
+============
 
-
-Maliput Integration
-===================
-
-* `Maliput Integration Tutorials <html/deps/maliput_integration/html/integration_tutorials.html>`_
-
+Please visit `Maliput Integration Tutorials <../../html/deps/maliput_integration/html/integration_tutorials.html>`_

--- a/docs/tutorials/maliput_malidrive.rst
+++ b/docs/tutorials/maliput_malidrive.rst
@@ -1,3 +1,8 @@
+.. _tutorial_maliput_malidrive_label:
+
+maliput_malidrive
+=================
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/tutorials/maliput_malidrive/maliput_malidrive_apps.rst
+++ b/docs/tutorials/maliput_malidrive/maliput_malidrive_apps.rst
@@ -1,5 +1,4 @@
+Applications
+============
 
-Maliput Malidrive
-=================
-
-* `Maliput Malidrive Tutorials <html/deps/maliput_malidrive/html/tutorials.html>`_
+Please visit `Maliput Malidrive Tutorials <../../html/deps/maliput_malidrive/html/tutorials.html>`_.

--- a/docs/tutorials/maliput_sparse.rst
+++ b/docs/tutorials/maliput_sparse.rst
@@ -1,3 +1,8 @@
+.. _tutorial_maliput_sparse_label:
+
+maliput_sparse
+==============
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/tutorials/maliput_sparse/creating_maliput_backend.rst
+++ b/docs/tutorials/maliput_sparse/creating_maliput_backend.rst
@@ -1,5 +1,11 @@
+.. _creating_maliput_backend_label:
+
 Creating a maliput backend using maliput_sparse
 ===============================================
+
+.. contents:: Contents
+   :depth: 2
+   :local:
 
 Context
 -------


### PR DESCRIPTION
# 🦟 Bug fix

Closes #127 

## Summary
Tutorials are now nested under the tutorials section.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

