### PR TITLE
Adds .readthedocs.yaml configuration file.

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,0 +1,13 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+formats:
+   - htmlzip


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #134 

## Summary
Adds configuration file and omits to add a pdf version of the page.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
