### PR TITLE
Fixes workflow's cp statement to copy also hidden files.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
       working-directory: ${{ env.ROS_WS }}
       run: |
         rm -rf src/${{ env.PACKAGE_NAME }}/*
-        cp -r install/maliput_documentation/share/docs/* src/${{ env.PACKAGE_NAME }}/
+        cp -r install/maliput_documentation/share/docs/ src/${{ env.PACKAGE_NAME }}/
         echo $(date) > src/${{ env.PACKAGE_NAME }}/build_stamp
         cd src/${{ env.PACKAGE_NAME }}
         git config --local user.email 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
# 🦟 Bug fix

Related to #134 #135 

## Summary

Modify `cp` statement in order to copy all the files. Otherwise the `.readthedocs.yaml` configuration file wasn't being copied.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
