### PR TITLE
Indicates to add --include-eol-distros to rosdep update.

### DIFF
--- a/docs/developer_setup.rst
+++ b/docs/developer_setup.rst
@@ -146,7 +146,7 @@ Install dependencies via ``rosdep``
 
 .. code-block:: sh
 
-    rosdep update
+    rosdep update --include-eol-distros
     rosdep install -i -y --rosdistro $ROS_DISTRO --skip-keys "pybind11" --from-paths src
 
 
@@ -577,7 +577,7 @@ Install all underlay packages' dependencies
 .. code-block:: sh
 
     export ROS_DISTRO=foxy
-    rosdep update
+    rosdep update --include-eol-distros
     rosdep install -i -y --rosdistro $ROS_DISTRO --skip-keys "pybind11" --from-paths /opt/dsim-desktop/*
 
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Now that the foxy reached the end of life, we need to instruct developers to use "--include-eol-distros" when calling `rosdep update`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
