### PR TITLE
Fixes readthedocs config.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
       run: |
         rm -rf src/${{ env.PACKAGE_NAME }}/*
         cp -r install/maliput_documentation/share/docs/ src/${{ env.PACKAGE_NAME }}/
+        cp -r install/maliput_documentation/share/.readthedocs.yaml src/${{ env.PACKAGE_NAME }}/
         echo $(date) > src/${{ env.PACKAGE_NAME }}/build_stamp
         cd src/${{ env.PACKAGE_NAME }}
         git config --local user.email 'github-actions[bot]@users.noreply.github.com'

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,9 +4,14 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: conf.py
+   configuration: docs/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 formats:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,13 @@ if(BUILD_DOCS)
       share
   )
 
+  install(
+    FILES
+      .readthedocs.yaml
+    DESTINATION
+      share
+  )
+
 else()
   message(STATUS "Documentation build - Disabled")
 endif()


### PR DESCRIPTION
# 🦟 Bug fix

Related to #139 

## Summary
 - This PRs makes readthedocs happy
 
 Checked at: https://readthedocs.org/projects/maliput/builds/21995362/
 
 ## Pendings
 
To tackle in a follow up PR:
 - Reathedocs theme got disabled some time ago, we should bring it back.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
