### PR TITLE
Removes maliput_drake from CI.

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -7,7 +7,6 @@ repositories:
   maliput                   : { type: 'git', url: 'https://github.com/maliput/maliput.git',                               version: 'main' }
   maliput_object            : { type: 'git', url: 'https://github.com/maliput/maliput_object.git',                        version: 'main' }
   maliput_object_py         : { type: 'git', url: 'https://github.com/maliput/maliput_object_py.git',                     version: 'main' }
-  maliput_drake             : { type: 'git', url: 'https://github.com/maliput/maliput_drake.git',                         version: 'main' }
   maliput_integration       : { type: 'git', url: 'https://github.com/maliput/maliput_integration.git',                   version: 'main' }
   maliput_integration_tests : { type: 'git', url: 'https://github.com/maliput/maliput_integration_tests.git',             version: 'main' }
   maliput_malidrive         : { type: 'git', url: 'https://github.com/maliput/maliput_malidrive.git',                     version: 'main' }

--- a/docs/developer_guidelines.rst
+++ b/docs/developer_guidelines.rst
@@ -32,8 +32,6 @@ The following packages are provided:
 * Integration packages:
     * `maliput_integration`_
     * `maliput_integration_tests`_
-* Mathematical support:
-    * `maliput_drake`_
 * Utility packages:
     * `drake_vendor`_
 * Delphyne:
@@ -55,7 +53,6 @@ The following packages are provided:
 .. _maliput_viz: https://github.com/maliput/maliput_viz
 .. _maliput_integration: https://github.com/maliput/maliput_integration
 .. _maliput_integration_tests: https://github.com/maliput/maliput_integration_tests
-.. _maliput_drake: https://github.com/maliput/maliput_drake
 .. _drake_vendor: https://github.com/maliput/drake_vendor
 .. _delphyne: https://github.com/maliput/delphyne
 .. _delphyne_gui: https://github.com/maliput/delphyne_gui


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput_infrastructure/issues/309

:exclamation: :star2:  This PR needs to be merged in sync with others!

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
