### PR TITLE
Adds maliput backend section.

### DIFF
--- a/docs/creating_maliput_backend.rst
+++ b/docs/creating_maliput_backend.rst
@@ -1,7 +1,7 @@
 .. _creating_maliput_backend_label:
 
-Creating a maliput backend using maliput_sparse
-===============================================
+Use maliput_sparse for backend creation
+=======================================
 
 .. contents:: Contents
    :depth: 2

--- a/docs/gallery.rst
+++ b/docs/gallery.rst
@@ -1,3 +1,5 @@
+.. _gallery_label:
+
 *******
 Gallery
 *******

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,14 +17,16 @@ Contents
    installation
    getting_started
    examples
+   maliput_backends
+   road_network_parameters
 
 .. toctree::
    :caption: Documentation
    :maxdepth: 3
 
+   creating_maliput_backend
    tutorials
    api_documentation
-   maliput_backend_parameters
    design
    roadmap
    changelog

--- a/docs/maliput_backends.rst
+++ b/docs/maliput_backends.rst
@@ -1,0 +1,103 @@
+.. _maliput_backends_label:
+
+Maliput Backends
+================
+
+.. contents:: Table of Contents
+    :depth: 2
+
+
+`maliput` API is designed to be backend-agnostic. This means that per sei it does not provide a
+road format. Instead, it provides a set of interfaces that a backend must implement, so the backend's underlying format is
+hidden from the user.
+
+The following backends are currently available:
+
+.. list-table:: Maliput Backends
+   :widths: 25 25
+   :header-rows: 1
+   :align: left
+
+   * - Maliput Backend
+     - Underlying Road Format
+   * - `maliput_malidrive <https://github.com/maliput/maliput_malidrive>`__
+     - OpenDRIVE
+   * - `maliput_osm <https://github.com/maliput/maliput_osm>`__
+     - Lanelet2 (OSM-based)
+   * - `maliput_multilane <https://github.com/maliput/maliput_multilane>`__
+     - Custom
+   * - `maliput_dragway <https://github.com/maliput/maliput_dragway>`__
+     - Custom
+
+
+maliput_malidrive
+-----------------
+
+`maliput_malidrive <https://github.com/maliput/maliput_malidrive>`_ is a backend that implements the `maliput` API on top of the `OpenDRIVE` road format.
+The package provides several OpenDRIVE maps (`maliput_malidrive/resources <https://github.com/maliput/maliput_malidrive/tree/main/resources>`_) as example however any other OpenDRIVE map can be used.
+
+The `XODR parser <src/maliput_malidrive/xodr/README.md>`_ is a standalone library that is used by `maliput_malidrive` to parse OpenDRIVE maps.
+For more information about the XODR parser, see the `XODR parser README <src/maliput_malidrive/xodr/README.md>`_.
+
+Some characteristics:
+  * Supports a large subset of the OpenDRIVE(v1.5) specification.
+  * Lane Geometry can compose:
+      * Ground geometry: line and constant curvature arc.
+          * Supports piecewise defined geometries.
+      * Lane width: cubic polynomials.
+      * Elevations: cubic polynomials.
+      * Superelevations: cubic polynomials.
+
+.. raw:: html
+
+    <video controls width="600" autoplay loop>
+        <source src="gallery/town07.webm" type="video/webm">
+
+        Sorry, your browser doesn't support embedded videos.
+    </video>
+
+Used map: `Town07.xodr <https://github.com/maliput/maliput_malidrive/blob/main/resources/Town07.xodr>`_
+
+.. note::
+  See :ref:`gallery_label` section for more videos.
+
+maliput_osm
+-----------
+
+`maliput_osm <https://github.com/maliput/maliput_osm>`_ is a backend that implements the `maliput` API on top of the `Lanelet2` road format. This format is also 
+based on OpenStreetMap (OSM) data.
+The package provides several OSM maps (`maliput_osm/resources <https://github.com/maliput/maliput_osm/tree/main/resources/osm>`_) as example however any other OSM map can be used.
+
+Some characteristics:
+  * Supports a large subset of the OSM specification.
+  * Lanes are described by a collection of polylines that are linearly interpolated.
+
+
+maliput_multilane
+-----------------
+
+`maliput_multilane <https://github.com/maliput/maliput_multilane>`_ is a backend that implements the `maliput` API on top of a custom road format
+using YAML files. This backend is used for testing purposes only and it is an example of how to implement a backend with a really good support for a vast number of road geometries where the lane width remains constant.
+
+Some characteristics:
+  * Custom YAML specification for defining roads.
+  * Lane Geometry can compose:
+      * Ground geometry: line and constant curvature arc.
+      * Lane width: constant.
+      * Elevations: cubic polynomials.
+      * Superelevations: cubic polynomials.
+
+
+maliput_dragway
+---------------
+
+`maliput_dragway <https://github.com/maliput/maliput_multilane>`_ is a backend that implements the minimal of the `maliput` API.
+It is used for testing purposes only and it is an example of how to implement a backend.
+
+Some characteristics:
+  * Geometries:
+     * Straight roads with N lanes
+  * Cannot handle intersections
+
+
+

--- a/docs/maliput_backends.rst
+++ b/docs/maliput_backends.rst
@@ -36,11 +36,11 @@ maliput_malidrive
 `maliput_malidrive <https://github.com/maliput/maliput_malidrive>`_ is a backend that implements the `maliput` API for road networks which are described by the `OpenDRIVE` specification.
 The package provides several OpenDRIVE maps (`maliput_malidrive/resources <https://github.com/maliput/maliput_malidrive/tree/main/resources>`_) as example, however any other OpenDRIVE map can be used.
 
-The `XODR parser <src/maliput_malidrive/xodr/README.md>`_ is a standalone library that is used by `maliput_malidrive` to parse OpenDRIVE maps.
-For more information about the XODR parser, see the `XODR parser README <src/maliput_malidrive/xodr/README.md>`_.
+The `XODR parser <https://github.com/maliput/maliput_malidrive/blob/main/src/maliput_malidrive/xodr/README.md>`_ is a standalone library that is used by `maliput_malidrive` to parse OpenDRIVE maps.
+For more information about the XODR parser, see the `XODR parser README <https://github.com/maliput/maliput_malidrive/blob/main/src/maliput_malidrive/xodr/README.md>`_.
 
 Some characteristics:
-  * Supports a large subset of the OpenDRIVE(v1.5) specification.
+  * Supports a `large subset <https://github.com/maliput/maliput_malidrive/blob/main/src/maliput_malidrive/xodr/README.md>`_ of the OpenDRIVE(v1.5) specification.
   * Lane Geometry can compose:
       * Ground geometry: line and constant curvature arc.
           * Supports piecewise defined geometries.

--- a/docs/maliput_backends.rst
+++ b/docs/maliput_backends.rst
@@ -33,8 +33,8 @@ The following backends are currently available:
 maliput_malidrive
 -----------------
 
-`maliput_malidrive <https://github.com/maliput/maliput_malidrive>`_ is a backend that implements the `maliput` API on top of the `OpenDRIVE` road format.
-The package provides several OpenDRIVE maps (`maliput_malidrive/resources <https://github.com/maliput/maliput_malidrive/tree/main/resources>`_) as example however any other OpenDRIVE map can be used.
+`maliput_malidrive <https://github.com/maliput/maliput_malidrive>`_ is a backend that implements the `maliput` API for road networks which are described by the `OpenDRIVE` specification.
+The package provides several OpenDRIVE maps (`maliput_malidrive/resources <https://github.com/maliput/maliput_malidrive/tree/main/resources>`_) as example, however any other OpenDRIVE map can be used.
 
 The `XODR parser <src/maliput_malidrive/xodr/README.md>`_ is a standalone library that is used by `maliput_malidrive` to parse OpenDRIVE maps.
 For more information about the XODR parser, see the `XODR parser README <src/maliput_malidrive/xodr/README.md>`_.
@@ -64,9 +64,9 @@ Used map: `Town07.xodr <https://github.com/maliput/maliput_malidrive/blob/main/r
 maliput_osm
 -----------
 
-`maliput_osm <https://github.com/maliput/maliput_osm>`_ is a backend that implements the `maliput` API on top of the `Lanelet2` road format. This format is also 
+`maliput_osm <https://github.com/maliput/maliput_osm>`_ is a backend that implements the `maliput` API for the `Lanelet2` specification. This format is also
 based on OpenStreetMap (OSM) data.
-The package provides several OSM maps (`maliput_osm/resources <https://github.com/maliput/maliput_osm/tree/main/resources/osm>`_) as example however any other OSM map can be used.
+The package provides several OSM maps (`maliput_osm/resources <https://github.com/maliput/maliput_osm/tree/main/resources/osm>`_) as example, however any other OSM map can be used.
 
 Some characteristics:
   * Supports a large subset of the OSM specification.
@@ -91,13 +91,10 @@ Some characteristics:
 maliput_dragway
 ---------------
 
-`maliput_dragway <https://github.com/maliput/maliput_multilane>`_ is a backend that implements the minimal of the `maliput` API.
+`maliput_dragway <https://github.com/maliput/maliput_multilane>`_ is a backend that implements the `maliput` API with the most simple geometry: a flat straight surface on the ground.
 It is used for testing purposes only and it is an example of how to implement a backend.
 
 Some characteristics:
   * Geometries:
      * Straight roads with N lanes
   * Cannot handle intersections
-
-
-

--- a/docs/road_network_parameters.rst
+++ b/docs/road_network_parameters.rst
@@ -1,7 +1,7 @@
-.. _maliput_backend_parameters_label:
+.. _road_network_parameters_label:
 
-Maliput Backend Parameters
-**************************
+Road Network Parameters
+***********************
 
 
 .. contents:: Table of Contents
@@ -19,8 +19,8 @@ Some of these parameters may be optional, but some others are mandatory, therefo
 
   For more information about the plugin interface see `Getting Started:Maliput Python Interface <getting_started.html#maliput-python-interface>`_ and `Maliput Plugin Architecture`_ .
 
-Parameters of maliput backends
-==============================
+Parameters for each maliput backend
+===================================
 
 `maliput` doesn't impose any restriction on the parameters that a maliput backend may request, however it is expected that the parameters are passed as a string dictionary of key-value pairs to the backend loader.
 For documentation purposes, it is desirable that the keys are documented somewhere so that the users of the backend can know what parameters can be used and how.
@@ -46,8 +46,8 @@ It is recommended to follow this pattern when documenting the parameters of a ma
      - `parameters <html/deps/maliput_osm/html/group__builder__configuration__keys.html>`__
 
 
-Using maliput plugin architecture to load maliput backends
-==========================================================
+Using maliput plugin architecture to load a Road Network
+========================================================
 
 After a maliput backend is installed, it can be loaded using the plugin interface. The plugin interface provides a way to discover the maliput backends that are available in the system and to load them.
 

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -12,4 +12,3 @@ It is recommended to visit :ref:`getting_started_label` page before diving into 
 
    tutorials/maliput_malidrive
    tutorials/maliput_integration
-   tutorials/maliput_sparse

--- a/docs/tutorials/maliput_sparse.rst
+++ b/docs/tutorials/maliput_sparse.rst
@@ -1,9 +1,0 @@
-.. _tutorial_maliput_sparse_label:
-
-maliput_sparse
-==============
-
-.. toctree::
-   :maxdepth: 1
-
-   maliput_sparse/creating_maliput_backend


### PR DESCRIPTION
# 🎉 New feature

related to #145 

## Summary
 - Adds maliput backend section
 - Move around docs to make it more user friendly:
   - `maliput backend parameters` after `maliput backend` section
   - `backend creation with maliput sparse` moved to first steps 

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
